### PR TITLE
[optimization] Add loadArray(Array) instead load(Collection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Author: [Simone Todaro](https://github.com/SimoTod)
 
 Made with :heart: by [Cyber-Duck Ltd](http://www.cyber-duck.co.uk)
 
+Modified by [Messi89](https://github.com/messi89) & [OVERGEN](https://github.com/overgen)
+
 [Installation](#installation)  
 [Export Excel](#export-excel)  
 [Import Excel](#import-excel)  

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ The exporter class is fluent, then you can also write
 return Exporter::make('Excel')->load($yourCollection)->stream($yourFileName);
 ```
 
+The expoorter class can load array instead of collection
+```
+return Exporter::make('Excel')->loadArray($yourArray)->save($yourFileNameWithPath);
+```
+
 ### Generate and save an excel file
 Add  
 ```
@@ -63,6 +68,15 @@ return $excel->save($yourFileNameWithPath);
 The exporter class is fluent, then you can also write  
 ```
 return Exporter::make('Excel')->load($yourCollection)->save($yourFileNameWithPath);
+```
+
+### Auto Heading 
+When you export your data, the package will insert array keys as the first row (like a header). use createHeadeStyle to add style on your header.
+
+### Heading style
+You can use createHeaderstyle($isBold, $fontSize, $color, $wrapText, $backgroundColor) to add style to your header
+```
+return Exporter::make('Excel')->createHeaderStyle()->load($yourCollection)->save($yourFileNameWithPath);
 ```
 
 ### Advanced usage

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ return Exporter::make('Excel')->load($yourCollection)->save($yourFileNameWithPat
 ```
 
 ### Auto Heading 
-When you export your data, the package will insert array keys as the first row (like a header). use createHeadeStyle to add style on your header.
+When you export your data, the exporter will insert the array keys as the first row (like a header). use createHeadeStyle to customize this row.
 
 ### Heading style
 You can use createHeaderstyle($isBold, $fontSize, $color, $wrapText, $backgroundColor) to add style to your header

--- a/src/Contract/ExporterInterface.php
+++ b/src/Contract/ExporterInterface.php
@@ -1,6 +1,7 @@
 <?php
 namespace Cyberduck\LaravelExcel\Contract;
 
+use Box\Spout\Writer\Style\Color;
 use Illuminate\Database\Eloquent\Collection;
 
 interface ExporterInterface
@@ -10,4 +11,5 @@ interface ExporterInterface
     public function setSerialiser(SerialiserInterface $serialiser);
     public function save($filename);
     public function stream($filename);
+    public function createHeaderStyle($isBold, $fontSize, $color, $wrapText, $backgroundColor);
 }

--- a/src/Contract/ExporterInterface.php
+++ b/src/Contract/ExporterInterface.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 interface ExporterInterface
 {
     public function load(Collection $data);
+    public function loadArray(array $data);
     public function setSerialiser(SerialiserInterface $serialiser);
     public function save($filename);
     public function stream($filename);

--- a/src/Contract/SerialiserInterface.php
+++ b/src/Contract/SerialiserInterface.php
@@ -6,5 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 interface SerialiserInterface
 {
     public function getData(Model $data);
+    public function getDataFromStdClass($data);
     public function getHeaderRow(array $data);
 }

--- a/src/Contract/SerialiserInterface.php
+++ b/src/Contract/SerialiserInterface.php
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 interface SerialiserInterface
 {
     public function getData(Model $data);
-    public function getHeaderRow();
+    public function getHeaderRow(array $data);
 }

--- a/src/Exporter/AbstractSpreadsheet.php
+++ b/src/Exporter/AbstractSpreadsheet.php
@@ -27,6 +27,13 @@ abstract class AbstractSpreadsheet implements ExporterInterface
         return $this;
     }
 
+    public function loadArray(array $data)
+    {
+        $this->data = $data;
+        return $this;
+    }
+
+
     public function setSerialiser(SerialiserInterface $serialiser)
     {
         $this->serialiser = $serialiser;
@@ -58,12 +65,19 @@ abstract class AbstractSpreadsheet implements ExporterInterface
 
     protected function makeRows($writer)
     {
-        $headerRow = $this->serialiser->getHeaderRow();
+        //heading
+        $headerRow = $this->serialiser->getHeaderRow($this->data);
+
         if (!empty($headerRow)) {
             $writer->addRow($headerRow);
         }
+
+        //data
         foreach ($this->data as $record) {
-            $writer->addRow($this->serialiser->getData($record));
+            if(is_array($record))
+                $writer->addRow($record);
+            else
+                $writer->addRow($this->serialiser->getData($record));
         }
         return $writer;
     }

--- a/src/Serialiser/BasicSerialiser.php
+++ b/src/Serialiser/BasicSerialiser.php
@@ -11,6 +11,10 @@ class BasicSerialiser implements SerialiserInterface
         return $data->toArray();
     }
 
+    public function getDataFromStdClass($data) {
+        return get_object_vars($data);
+    }
+
     public function getHeaderRow(array $data=null)
     {
         if($data != null) {

--- a/src/Serialiser/BasicSerialiser.php
+++ b/src/Serialiser/BasicSerialiser.php
@@ -11,8 +11,23 @@ class BasicSerialiser implements SerialiserInterface
         return $data->toArray();
     }
 
-    public function getHeaderRow()
+    public function getHeaderRow(array $data=null)
     {
+        if($data != null) {
+            // Get the first row
+            $firstRow = reset($data);
+
+            // Get the array/object keys
+            if (is_array($firstRow))
+                $tableHeading = array_keys($firstRow);
+            else
+                $tableHeading = array_keys(get_object_vars($firstRow));
+
+            //return the heading tab
+            return $tableHeading;
+        }
+
+        //no heading
         return [];
     }
 }


### PR DESCRIPTION
Hi guys,

I added support to load directly an array of arrays or an array of objects (stdClass) from QueryBuilder instead of load collection from Eloquent.

collection->toArray() isn't suitable with big data (more than 10k rows)

I added auto heading from array keys and createHeadingStyle (fluent), you can check the readme