### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $collection = $excel->getCollection();
 
 The importer class is fluent, then you can also write
 ```
-return Importer::make('Excel')->getCollection($filepath)->getCollection();
+return Importer::make('Excel')->load($filepath)->getCollection();
 ```
 
 ### Advanced usage
@@ -157,7 +157,7 @@ use Cyberduck\LaravelExcel\Contract\ParserInterface;
 
 class ExampleSerialiser implements ParserInterface
 {
-    public function transform($row)
+    public function transform($row, $headers)
     {
         $model = new YourModel();
         $model->field1 = $row[0];
@@ -168,6 +168,7 @@ class ExampleSerialiser implements ParserInterface
     }
 }
 ```
+
 
 ## Different formats
 The package supports ODS and CSV files.

--- a/src/Importer/AbstractSpreadsheet.php
+++ b/src/Importer/AbstractSpreadsheet.php
@@ -120,6 +120,7 @@ abstract class AbstractSpreadsheet implements ImporterInterface
                     $data = $this->parser->transform($row, $headers);
                     if ($data !== false) {
                         $relationships = [];
+                        $data = $data['attributes'];
                         $when = array_intersect_key($data, $updateIfEquals);
                         $values = array_diff_key($data, $when);
 


### PR DESCRIPTION
1. importing data into eloquent model using transform function on the ParserInterface throws exception error if the second parameter $headers is eliminated.
2. users should be aware they  need to setParser and also setModel on the Import class before importing data into eloquent model.
3. changed Importer::make('Excel')->getCollection($filepath)->getCollection(); to return Importer::make('Excel')->load($filepath)->getCollection(); -  results in error if not noticed.