### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ use Cyberduck\LaravelExcel\Contract\SerialiserInterface;
 
 class ExampleSerialiser implements SerialiserInterface
 {
-    public function getData(Model $data)
+    public function getData($data)
     {
         $row = [];
 


### PR DESCRIPTION
*getData(Model $data)* must return an array of string, and every elements is a cell. - Casting against the MODEL in the getData() produce error. It expects an array $data.  It should be getData($data)  instead. Thanks